### PR TITLE
Adding valid and invalid props to date picker...

### DIFF
--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -443,7 +443,7 @@ class DatePicker extends React.Component {
       <InputGroup
         size      = {this.props.size}
         id        = {`rdp-input-group-${this.idSuffix}`}
-        className = {'rdp-input-group'}
+        className = {`rdp-input-group${this.props.invalid ? ' is-invalid' : ''}${this.props.valid ? ' is-valid' : ''}`}
       >
         {control}
         
@@ -549,7 +549,9 @@ DatePicker.propTypes= {
 
   ]),
   onInvalid: PropTypes.func,
-  noValidate: PropTypes.bool
+  noValidate: PropTypes.bool,
+  valid: PropTypes.bool, // applied the is-valid class when true, does nothing when false
+  invalid: PropTypes.bool // applied the is-invalid class when true, does nothing when false
 }
 
 

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -1399,4 +1399,80 @@ describe('DatePicker', function () {
     ReactDOM.unmountComponentAtNode(container)
   }))
   
+  it("should not include the is-invalid class when invalid is false", co.wrap(function *(){
+    const id = UUID.v4()
+    class App extends React.Component {
+      render() {
+        return (
+          <div>
+            <DatePicker id={id} invalid={false} />
+          </div>
+        )
+      }
+    }
+    yield new Promise(function(resolve, _reject){
+      ReactDOM.render(<App />, container, resolve)
+    })
+    const hiddenInputElement = document.getElementById(`rdp-input-group-${id}`)
+    assert.equal(hiddenInputElement.classList.contains('is-invalid'), false)
+    ReactDOM.unmountComponentAtNode(container)
+  }))
+  
+  it("should include the is-invalid class when invalid is true", co.wrap(function *(){
+    const id = UUID.v4()
+    class App extends React.Component {
+      render() {
+        return (
+          <div>
+            <DatePicker id={id} invalid={true} />
+          </div>
+        )
+      }
+    }
+    yield new Promise(function(resolve, _reject){
+      ReactDOM.render(<App />, container, resolve)
+    })
+    const hiddenInputElement = document.getElementById(`rdp-input-group-${id}`)
+    assert.equal(hiddenInputElement.classList.contains('is-invalid'), true)
+    ReactDOM.unmountComponentAtNode(container)
+  }))
+  
+  it("should not include the is-valid class when invalid is false", co.wrap(function *(){
+    const id = UUID.v4()
+    class App extends React.Component {
+      render() {
+        return (
+          <div>
+            <DatePicker id={id} valid={false} />
+          </div>
+        )
+      }
+    }
+    yield new Promise(function(resolve, _reject){
+      ReactDOM.render(<App />, container, resolve)
+    })
+    const hiddenInputElement = document.getElementById(`rdp-input-group-${id}`)
+    assert.equal(hiddenInputElement.classList.contains('is-valid'), false)
+    ReactDOM.unmountComponentAtNode(container)
+  }))
+  
+  it("should include the is-valid class when invalid is true", co.wrap(function *(){
+    const id = UUID.v4()
+    class App extends React.Component {
+      render() {
+        return (
+          <div>
+            <DatePicker id={id} valid={true} />
+          </div>
+        )
+      }
+    }
+    yield new Promise(function(resolve, _reject){
+      ReactDOM.render(<App />, container, resolve)
+    })
+    const hiddenInputElement = document.getElementById(`rdp-input-group-${id}`)
+    assert.equal(hiddenInputElement.classList.contains('is-valid'), true)
+    ReactDOM.unmountComponentAtNode(container)
+  }))
+  
 })


### PR DESCRIPTION
to allow bootstrap classes 'is-invalid' and 'is-valid' to be added to rendered element.

Addresses issue https://github.com/afialapis/reactstrap-date-picker/issues/7