### PR TITLE
IE11 compat: babel on arrow funcs and classes.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
 ],
 "plugins": [
   // Stage 3
-  ["@babel/plugin-proposal-class-properties", { "loose": true }],
+  ["@babel/plugin-transform-classes",
+  "@babel/plugin-proposal-class-properties", { "loose": true }],
+  "@babel/plugin-transform-arrow-functions",
   "@babel/plugin-syntax-dynamic-import",
   "@babel/plugin-proposal-object-rest-spread"
   // ["module:fast-async"]

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@babel/plugin-proposal-class-properties": "7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "7.5.5",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
+    "@babel/plugin-transform-arrow-functions": "7.10.1",
+    "@babel/plugin-transform-classes": "7.10.3",
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
Addresses issue https://github.com/afialapis/reactstrap-date-picker/issues/9